### PR TITLE
Added API routes for media posts on Next.js side and client-side fetching of media posts

### DIFF
--- a/credmark-website/actions/index.js
+++ b/credmark-website/actions/index.js
@@ -4,6 +4,10 @@ const fetcher = url => fetch(url).then(res => res.json())
 
 export const useGetHello = () => useSWR('/api/hello', fetcher);
 
-export const useGetPosts = (initialData) => {
-    return useSWR(`/api/posts`, fetcher, {initialData})
+export const useGetPosts = (fallbackData) => {
+    return useSWR(`/api/posts`, fetcher, {fallbackData})
+}
+
+export const useGetMediaPosts = (fallbackData) => {
+    return useSWR(`/api/mediaPosts`, fetcher, {fallbackData})
 }

--- a/credmark-website/components/pages/faq.js
+++ b/credmark-website/components/pages/faq.js
@@ -28,7 +28,7 @@ export default function faq() {
                                     <li>$CMK will be used in our governance platform and gives voting rights to the public - users can use their CMK to vote on the quality of models produced in the Credmark community.</li>
                                     <li>$CMK will be used to reward the community of data scientists for making models. Furthermore, modelers have to stake $CMK in order to submit their models.</li>
                                 </ul>
-                                <p className="font-extrabold pb-1-">How does Credmark encourage data model contributors?</p>
+                                <p className="font-extrabold pb-1-">How does Credmark encourage data model contributors? </p>
                                 <p className="font-thin pb-10">Model contributors will be compensated based on the efficacy and use of their models. Once a model has been submitted and validated on our platform it will enter a leaderboard. The more effective and popular a model is, the higher it will go on the leaderboard- the model contributors at the top of the leaderboard are rewarded out of our community treasury. Because we funnel the fees from retail use back into our community treasury, there will always be rewards available for model contributors.</p>
                                 <p className="font-extrabold pb-5">How can a Credmark user tell if a model is accurate or not?</p>
                                 <p className="font-thin pb-10">Governance dictates the success metrics used by the models. Each category for models has its own metrics and the accuracy is determined by open and transparent ML backtesting methods. To avoid overfitting, we test the models against live data for a period of time.</p>

--- a/credmark-website/pages/api/mediaPosts.js
+++ b/credmark-website/pages/api/mediaPosts.js
@@ -1,0 +1,6 @@
+import { getAllMediaPosts } from "../../lib/api";
+
+export default async function getMediaPosts(req, res){
+    const data = await getAllMediaPosts();
+    res.status(200).json(data);
+}

--- a/credmark-website/pages/blog.js
+++ b/credmark-website/pages/blog.js
@@ -16,6 +16,8 @@ export default function BlogPage({ posts }) {
         <title>Blog | CREDMARK</title>
         <meta content="Blog | Credmark" property="og:title" key="og:title" />
         <meta name="description" content="Welcome to the Credmark blog. Subscribe to find out about company updates and industry research." />
+        <meta property="og:title" content="Blog | Credmark" key="ogtitle" />
++       <meta property="og:description" content="Welcome to the Credmark blog. Subscribe to find out about company updates and industry research." key="ogdesc" />
         <link rel="icon" href="/favicon.ico" />
           {/* Global Site Tag (gtag.js) - Google Analytics */}
           <script

--- a/credmark-website/pages/crypto-credit-report.js
+++ b/credmark-website/pages/crypto-credit-report.js
@@ -9,6 +9,8 @@ export default function CryptoReportPage() {
         <title>Media and Crypto Reports | CREDMARK</title>
         <meta content="Media and Crypto Reports | Credmark" property="og:title" key="og:title" />
         <meta name="description" content="Check out our latest press articles and crypto credit reports." />
+        <meta property="og:title" content="Media and Crypto Reports | Credmark" key="ogtitle" />
++       <meta property="og:description" content="Check out our latest press articles and crypto credit reports." key="ogdesc" />
         <link rel="icon" href="/favicon.ico" />
           {/* Global Site Tag (gtag.js) - Google Analytics */}
           <script

--- a/credmark-website/pages/faq.js
+++ b/credmark-website/pages/faq.js
@@ -10,6 +10,8 @@ export default function FAQPage() {
                 <title>FAQ | CREDMARK</title>
                 <meta content="FAQ | Credmark" property="og:title" key="og:title" />
                 <meta name="description" content="Find out the answers to any of your Credmark related questions." />
+                <meta property="og:title" content="FAQ | Credmark" key="ogtitle" />
+                <meta property="og:description" content="Find out the answers to any of your Credmark related questions." key="ogdesc" />
                 <link rel="icon" href="/favicon.ico" />
                 {/* Global Site Tag (gtag.js) - Google Analytics */}
                 <script

--- a/credmark-website/pages/index.js
+++ b/credmark-website/pages/index.js
@@ -9,6 +9,8 @@ export default function Home() {
         <title>CREDMARK</title>
         <meta content="Credmark | High Integrity Data | Risk Modeling" property="og:title" key="og:title" />
         <meta name="description" content="Credmark aims to provide high integrity data and risk metrics through a transparent, community-driven platform." />
+        <meta property="og:title" content="Credmark | High Integrity Data | Risk Modeling" key="ogtitle" />
+         <meta property="og:description" content="Credmark aims to provide high integrity data and risk metrics through a transparent, community-driven platform." key="ogdesc" />
         <link rel="icon" href="/favicon.ico" />
           {/* Global Site Tag (gtag.js) - Google Analytics */}
           <script

--- a/credmark-website/pages/media.js
+++ b/credmark-website/pages/media.js
@@ -3,8 +3,13 @@ import Media from '../components/pages/media'
 import Nav from '../components/layout/nav'
 
 import { getAllMediaPosts } from "../lib/api"
+import { useGetMediaPosts } from '../actions'
 
-export default function Home({posts}) {
+export default function Home({posts: initialPosts}) {
+  // 'posts' is pre-filled with posts cached when getStaticProps() was run during build time
+  // then will be fetched fresh on client-side
+  const { data: posts } = useGetMediaPosts(initialPosts);
+
   return (
     <>
       <Head>
@@ -44,6 +49,6 @@ export async function getStaticProps() {
   return {
       props: {
           posts
-      }
+      },
   };
 }

--- a/credmark-website/pages/media.js
+++ b/credmark-website/pages/media.js
@@ -16,6 +16,8 @@ export default function Home({posts: initialPosts}) {
         <title>Media and Crypto Reports | CREDMARK</title>
         <meta content="Media and Crypto Reports | Credmark" property="og:title" key="og:title" />
         <meta name="description" content="Check out our latest press articles and crypto credit reports." />
+        <meta property="og:title" content="Media and Crypto Reports | Credmark" key="ogtitle" />
++       <meta property="og:description" content="Check out our latest press articles and crypto credit reports." key="ogdesc" />
         <link rel="icon" href="/favicon.ico" />
           {/* Global Site Tag (gtag.js) - Google Analytics */}
           <script

--- a/credmark-website/pages/team.js
+++ b/credmark-website/pages/team.js
@@ -9,6 +9,8 @@ export default function TeamPage() {
         <title>Team | CREDMARK</title>
         <meta content="Team | Credmark" property="og:title" key="og:title" />
         <meta name="description" content="Meet the team behind Credmark and our advisors." />
+        <meta property="og:title" content="Team | Credmark" key="ogtitle" />
+         <meta property="og:description" content="Meet the team behind Credmark and our advisors." key="ogdesc" />
         <link rel="icon" href="/favicon.ico" />
           {/* Global Site Tag (gtag.js) - Google Analytics */}
           <script

--- a/credmark-website/pages/whitepaper.js
+++ b/credmark-website/pages/whitepaper.js
@@ -9,6 +9,8 @@ export default function WhitepaperPage() {
         <title>Whitepaper | CREDMARK</title>
         <meta content="Whitepaper | Credmark" property="og:title" key="og:title" />
         <meta name="description" content="Our White Paper offers an in-depth look into the Credmark platform - how we generate high integrity data and how our models are built and delivered." />
+        <meta property="og:title" content="Whitepaper | Credmark" key="ogtitle" />
+        <meta property="og:description" content="Our White Paper offers an in-depth look into the Credmark platform - how we generate high integrity data and how our models are built and delivered." key="ogdesc" />
         <link rel="icon" href="/favicon.ico" />
           {/* Global Site Tag (gtag.js) - Google Analytics */}
           <script


### PR DESCRIPTION
I also changed `initialData` to `fallbackData` in `actions/index.js` because SWR v1 has changed it.
See https://swr.vercel.app/blog/swr-v1#fallback-data
